### PR TITLE
Adding Support for Label Base Node Selection

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -14,3 +14,6 @@ flags:
     shorthand: i
     desc: Identity file to use for the ssh command.
     defValue: ~/.ssh/id_rsa
+  - name: selector
+    shorthand: l
+    desc: Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)

--- a/readme.adoc
+++ b/readme.adoc
@@ -36,19 +36,21 @@ following.
 
 [source,shell]
 ----
-$ kubectl plugin ssh --help
-Opens up an SSH connection to the node that you pass into the command, allowing you to work faster
-without writing out the full ssh command.
+Opens up an SSH connection to the node that you pass into the command, allowing you to work faster without writing out
+the full ssh command.
 
 Examples:
   kubectl plugin ssh <node-name>
 
 Options:
   -i, --identity-file='~/.ssh/id_rsa': Identity file to use for the ssh command.
+  -l, --selector='': Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
   -u, --ssh-user='admin': User to use for the ssh command.
 
 Usage:
   kubectl plugin ssh [flags] [options]
+
+Use "kubectl options" for a list of global command-line options (applies to all commands).
 ----
 
 == Roadmap

--- a/ssh.sh
+++ b/ssh.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
-if [ -z "$1" ]
+if [ "$KUBECTL_PLUGINS_LOCAL_FLAG_SELECTOR" == "" ] && [ -z "$1" ]
 then
   echo "Node name cannot be empty"
   exit 1
 else
-  hostname=$(kubectl get node $1 -o jsonpath="{.status.addresses[?(.type=='ExternalDNS')].address}")
+  if [ "$KUBECTL_PLUGINS_LOCAL_FLAG_SELECTOR" == "" ]
+  then
+    selector=""
+    path="{.status.addresses[?(.type=='ExternalDNS')].address}"
+  else
+    selector="-l $KUBECTL_PLUGINS_LOCAL_FLAG_SELECTOR"
+    path="{.items[0].status.addresses[?(.type=='ExternalDNS')].address}"
+  fi
+  hostname=$(kubectl get node $1 -o jsonpath="${path}" $selector)
   ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$hostname
 fi


### PR DESCRIPTION
**Why:**

* Now you can use the `ssh` plugin with `-l` to select specfic nodes
* allows you to use -l kubernetes.io/role=master or kubernetes.io/role=worker to select an instance

**This change addresses the need by:**

* closes #2

Signed-off-by: Christopher Hein <me@christopherhein.com>