### PR TITLE
search for ExternalIP in nodes status if ExternalDNS is not available

### DIFF
--- a/ssh.sh
+++ b/ssh.sh
@@ -8,17 +8,11 @@ else
   if [ "$KUBECTL_PLUGINS_LOCAL_FLAG_SELECTOR" == "" ]
   then
     selector=""
-    path="{.status.addresses[?(.type=='ExternalDNS')].address}"
+    path="{.status.addresses[?(.type == 'ExternalIP')].address}"
   else
     selector="-l $KUBECTL_PLUGINS_LOCAL_FLAG_SELECTOR"
-    path="{.items[0].status.addresses[?(.type=='ExternalDNS')].address}"
+    path="{.items[0].status.addresses[?(.type=='ExternalIP')].address}"
   fi
   hostname=$(kubectl get node $1 -o jsonpath="${path}" $selector)
-  [[ -z $hostname ]] && hostname=$(kubectl get node $1 -o jsonpath="${path/ExternalDNS/ExternalIP}" $selector)
-  if [[ ! -z $hostname  ]]; then
-    ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$hostname
-  else
-    echo "Can't find Public DNS/IP"
-    exit 1
-  fi
+  [[ ! -z $hostname  ]] && ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$hostname || echo "Can't find Public DNS/IP"; exit 1;
 fi

--- a/ssh.sh
+++ b/ssh.sh
@@ -14,5 +14,11 @@ else
     path="{.items[0].status.addresses[?(.type=='ExternalDNS')].address}"
   fi
   hostname=$(kubectl get node $1 -o jsonpath="${path}" $selector)
-  ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$hostname
+  [[ -z $hostname ]] && hostname=$(kubectl get node $1 -o jsonpath="${path/ExternalDNS/ExternalIP}" $selector)
+  if [[ ! -z $hostname  ]]; then
+    ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$hostname
+  else
+    echo "Can't find Public DNS/IP"
+    exit 1
+  fi
 fi

--- a/ssh.sh
+++ b/ssh.sh
@@ -14,5 +14,5 @@ else
     path="{.items[0].status.addresses[?(.type=='ExternalIP')].address}"
   fi
   hostname=$(kubectl get node $1 -o jsonpath="${path}" $selector)
-  [[ ! -z $hostname  ]] && ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$hostname || echo "Can't find Public DNS/IP"; exit 1;
+  [[ ! -z $hostname  ]] && ssh -i ${KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE} ${KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USER}@$hostname || echo "Can't find ExternalIP"; exit 1;
 fi


### PR DESCRIPTION
HI, I like your small kubectl-ssh plugin. I tried it with GKE, but it didn't work as GKE doesn't use ExternalDNS. This PR should solve it. The solution is not the most elegant, but there is a bug in using regex within jsonpath: https://github.com/kubernetes/kubernetes/issues/61406.